### PR TITLE
更改名词“colorMode”

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -189,7 +189,7 @@ const config = {
         ],
         copyright: `Copyright © ${new Date().getFullYear()} IvorySQL.`,
       },
-      colorMode: {
+      ColorModeToggle: {
         defaultMode: 'light',
         disableSwitch: true,
         respectPrefersColorScheme: false,


### PR DESCRIPTION
因为docusaurus现在已经弃用colorMode，改为用colorModeToggle，故做修改