### PR TITLE
feat: add AtomGit link to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -254,6 +254,10 @@ const config = {
                 href: 'https://github.com/IvorySQL/IvorySQL',
               },
               {
+                label: 'IvorySQL AtomGit',
+                href: 'https://atomgit.com/IvorySQL/IvorySQL',
+              },
+              {
                 label: 'IvorySQL Gitee',
                 href: 'https://gitee.com/IvorySQL/',
               },

--- a/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -47,6 +47,10 @@
     "message": "IvorySQL Gitee",
     "description": "The label of footer link with label=IvorySQL Gitee linking to https://gitee.com/IvorySQL/"
   },
+  "link.item.label.IvorySQL AtomGit": {
+    "message": "IvorySQL AtomGit",
+    "description": "The label of footer link with label=IvorySQL AtomGit linking to https://atomgit.com/IvorySQL/IvorySQL"
+  },
   "link.item.label.Report an issue": {
     "message": "提交问题",
     "description": "The label of footer link with label=Report an issue linking to https://github.com/IvorySQL/IvorySQL/issues/new/choose"


### PR DESCRIPTION
close #263 
Add IvorySQL AtomGit (https://atomgit.com/IvorySQL/IvorySQL) link to the site footer in both English and Chinese locales.